### PR TITLE
Add App() and GetContextRuntimeType()

### DIFF
--- a/places/lib/main.dart
+++ b/places/lib/main.dart
@@ -1,7 +1,17 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(App());
+}
+
+class App extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'App title',
+      home: MyFirstStatefulWidget(),
+    );
+  }
 }
 
 class MyApp extends StatelessWidget {
@@ -129,6 +139,9 @@ class MyFirstWidget extends StatelessWidget {
       ),
     );
   }
+
+  // Ошибка: The getter 'context' isn't defined for the class 'MyFirstWidget'
+  // Type getContextRuntimeType() => context.runtimeType;
 }
 
 class MyFirstStatefulWidget extends StatefulWidget {
@@ -148,4 +161,7 @@ class _MyFirstStatefulWidgetState extends State<MyFirstStatefulWidget> {
       ),
     );
   }
+
+  // Работает, т.к. в классе State есть геттер для context
+  Type getContextRuntimeType() => context.runtimeType;
 }


### PR DESCRIPTION
1.. После переименования main.dart в start.dart получаем сообщение "Target file "lib\main.dart" not found.", т.к. точкой входа в приложение является функция main() расположенная, по умолчанию, в файле main.dart

4.. Судя по описанию - на Android title, заданный для MaterialApp, будет показан над снимком приложения в диспетчере задач, который вызывается, когда пользователь нажимает кнопку "Недавние приложения". Практически у меня в эмуляторе title не выводится, видимо зависит от устройства и версии эмулятора.

5.. если не предпринимать никаких дополнительных действий - для StatelessWidget, context доступен только в методе build.
Поэтому, при попытке реализации метода:
`Type getContextRuntimeType() => context.runtimeType;`
получаем ошибку: The getter 'context' isn't defined for the class 'MyFirstWidget'

6.. У StatefulWidget в State есть геттер для context, поэтому метод:
`Type getContextRuntimeType() => context.runtimeType;`
будет работать