### PR TITLE
4 16 themes

### DIFF
--- a/places/lib/main.dart
+++ b/places/lib/main.dart
@@ -10,8 +10,8 @@ void main() {
 }
 
 class App extends StatelessWidget {
-  bool isDarkMode = true;
-  // bool isDarkMode = false;
+  // bool isDarkMode = true;
+  bool isDarkMode = false;
 
   @override
   Widget build(BuildContext context) {

--- a/places/lib/main.dart
+++ b/places/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:places/mocks.dart';
+import 'package:places/ui/screen/res/themes.dart';
 import 'package:places/ui/screen/sight_detail.dart';
 import 'package:places/ui/screen/sight_list_screen.dart';
 import 'package:places/ui/screen/visiting_screen.dart';
@@ -9,12 +10,16 @@ void main() {
 }
 
 class App extends StatelessWidget {
+  bool isDarkMode = true;
+  // bool isDarkMode = false;
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'App title',
+      theme: isDarkMode ? darkTheme : lightTheme,
       home:
-          VisitingScreen(), // SightDetail(sight: mocks[1]), // SightListScreen(),
+          VisitingScreen(), // SightDetail(sight: mocks[2]), // SightListScreen(),
     );
   }
 }

--- a/places/lib/ui/res/colors.dart
+++ b/places/lib/ui/res/colors.dart
@@ -1,38 +1,36 @@
-// import 'dart:ui';
 import 'package:flutter/material.dart';
-
-// Семантические алиасы
-// Пополняются по мере необходимости
-// Используют только основную палитру
-const Color dividerColor = _slateGrey,
-    textColorPrimary = _blueZodiac,
-    textColorSlateGrey = _slateGrey,
-    textColorWhite = _white,
-    textColorLuckyPoint = _luckyPoint,
-    tabbarColorBackground = _whiteSmoke,
-    tabbarColorIndicator = _blueZodiac;
-// colorAccent = _purple,
-// colorError = _freeSpeechRed,
-// btnColor = _alizarin,
-// hintColor = _darkGrey,
-// backgroundColor = _pastelWhite,
-// appBarColor = _white,
-// white = _white,
-// textColorSecondary = _darkGrey,
-// textColorPrimary = _oxfordBlue,
-// textColorGrey = _grey;
 
 // Основная палитра (http://www.color-blindness.com/color-name-hue/)
 const Color _slateGrey = Color(0xFF7C7E92),
     _blueZodiac = Color(0xFF3B3E5B),
     _white = Colors.white,
     _whiteSmoke = Color(0xFFF5F5F5),
-    _luckyPoint = Color(0xFF252849);
-// _oxfordBlue = Color(0xFF263238),
-// _purple = Color(0xFF7A3E93),
-// _freeSpeechRed = Color(0xFFB00000),
-// _alizarin = Color(0xFFE31E24),
-// _pastelWhite = Color(0xFFFAFAFA),
-// _solitude = Color(0xFFE5E8EB),
-// _darkGrey = Color(0xFFA7A7A7),
-// _grey = Color(0x8A000000);
+    _luckyPoint = Color(0xFF252849),
+    _blackRussian = Color(0xFF21222C),
+    _blackDark = Color(0xFF1A1A20);
+
+// Семантические алиасы
+// Пополняются по мере необходимости
+// Используют только основную палитру
+
+// Универсальные
+const Color textColorBlueZodiac = _blueZodiac,
+    textColorSlateGrey = _slateGrey,
+    textColorWhite = _white,
+    textColorLuckyPoint = _luckyPoint;
+
+// Светлая схема
+const Color lightBackgroundColor = _white,
+    lightTabbarColorBackground = _whiteSmoke,
+    lightTabbarColorIndicator = _blueZodiac,
+    lightSightDetailDividerColor = _slateGrey,
+    lightSightDetailButtonColor = _blueZodiac,
+    lightSightCardBackgroundColor = _whiteSmoke;
+
+// Темная схема
+const Color darkBackgroundColor = _blackRussian,
+    darkTabbarColorBackground = _blackDark,
+    darkTabbarColorIndicator = _white,
+    darkSightDetailDividerColor = _slateGrey,
+    darkSightDetailButtonColor = _white,
+    darkSightCardBackgroundColor = _blackDark;

--- a/places/lib/ui/res/text_styles.dart
+++ b/places/lib/ui/res/text_styles.dart
@@ -4,7 +4,6 @@ import 'package:places/ui/res/colors.dart';
 /// Стили текстов
 TextStyle _text = const TextStyle(
       fontStyle: FontStyle.normal,
-      color: textColorPrimary,
     ),
 
 //Light
@@ -13,17 +12,27 @@ TextStyle _text = const TextStyle(
 //Regular (w400)
     textRegular = _text.copyWith(fontWeight: FontWeight.normal),
     textRegular14 = textRegular.copyWith(fontSize: 14.0, height: 18.0 / 14.0),
+    textRegular14BlueZodiac =
+        textRegular14.copyWith(color: textColorBlueZodiac),
+    textRegular14White = textRegular14.copyWith(color: textColorWhite),
     textRegular14SlateGrey = textRegular14.copyWith(color: textColorSlateGrey),
 
 //Medium
     textMedium = _text.copyWith(fontWeight: FontWeight.w500),
     textMedium16 = textMedium.copyWith(fontSize: 16.0, height: 20.0 / 16.0),
+    textMedium16BlueZodiac = textMedium16.copyWith(color: textColorBlueZodiac),
+    textMedium16White = textMedium16.copyWith(color: textColorWhite),
     textMedium18 = textMedium.copyWith(fontSize: 18.0, height: 24.0 / 18.0),
     textMedium18LuckyPoint = textMedium18.copyWith(color: textColorLuckyPoint),
+    textMedium18White = textMedium18.copyWith(color: textColorWhite),
 
 //Bold (w700)
     textBold = _text.copyWith(fontWeight: FontWeight.bold),
     textBold14 = textBold.copyWith(fontSize: 14.0, height: 18.0 / 14.0),
+    textBold14BlueZodiac = textBold14.copyWith(color: textColorBlueZodiac),
     textBold14White = textBold14.copyWith(color: textColorWhite),
+    textBold14SlateGrey = textBold14.copyWith(color: textColorSlateGrey),
     textBold24 = textBold.copyWith(fontSize: 24.0, height: 28.8 / 24.0),
+    textBold24BlueZodiac = textBold24.copyWith(color: textColorBlueZodiac),
+    textBold24White = textBold24.copyWith(color: textColorWhite),
     textBold32 = textBold.copyWith(fontSize: 32.0);

--- a/places/lib/ui/screen/app_com.dart
+++ b/places/lib/ui/screen/app_com.dart
@@ -14,6 +14,7 @@ class AppBottomNavigationBar extends StatelessWidget {
       type: BottomNavigationBarType.fixed,
       showSelectedLabels: false,
       showUnselectedLabels: false,
+      backgroundColor: Theme.of(context).backgroundColor,
       items: [
         BottomNavigationBarItem(
           icon: Icon(Icons.format_list_bulleted),

--- a/places/lib/ui/screen/res/themes.dart
+++ b/places/lib/ui/screen/res/themes.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:places/ui/res/colors.dart';
+import 'package:places/ui/res/text_styles.dart';
+
+/// Методика использование тем в приложении.
+///
+/// Основная тема приложения устанавливается для виджета [MaterialApp].
+/// Параметр [brightness] основной темы является ключевым и позволяет
+/// в дальнейшем, используя [Theme.of(context)], определить установленную
+/// сейчас тему (светлая или темная).
+///
+/// При необходимости, для отдельного виджета может быть установлена
+/// специализированная тема (пример - виджеты SightCard, DetailCard).
+/// Для этого виджет оборачивается в [Theme] где, в зависимости от значения
+/// параметра [brightness] основной темы, устанавливается специализированная
+/// тема - светлая или темная. Дополнительно используется [Builder] чтобы
+/// обновить [(context)] для последующих виджетов.
+
+/// Приложение - светлая тема
+final ThemeData lightTheme = ThemeData(
+  brightness: Brightness.light,
+  backgroundColor: lightBackgroundColor,
+  scaffoldBackgroundColor: lightBackgroundColor,
+  cardColor: lightTabbarColorBackground,
+  primaryTextTheme:
+      TextTheme(headline6: textMedium18LuckyPoint), // Заголовок в AppBar
+  tabBarTheme: TabBarTheme(
+    indicator: BoxDecoration(
+      borderRadius: BorderRadius.circular(40),
+      color: lightTabbarColorIndicator,
+    ),
+    labelColor: textColorWhite,
+    labelStyle: textBold14,
+    unselectedLabelColor: textColorSlateGrey,
+    unselectedLabelStyle: textBold14,
+  ),
+);
+
+/// Приложение - темная тема
+final ThemeData darkTheme = ThemeData(
+  brightness: Brightness.dark,
+  backgroundColor: darkBackgroundColor,
+  scaffoldBackgroundColor: darkBackgroundColor,
+  cardColor: darkTabbarColorBackground,
+  primaryTextTheme:
+      TextTheme(headline6: textMedium18White), // Заголовок в AppBar
+  tabBarTheme: TabBarTheme(
+    indicator: BoxDecoration(
+      borderRadius: BorderRadius.circular(40),
+      color: darkTabbarColorIndicator,
+    ),
+    labelColor: textColorBlueZodiac,
+    labelStyle: textBold14,
+    unselectedLabelColor: textColorSlateGrey,
+    unselectedLabelStyle: textBold14,
+  ),
+);
+
+/// Карточка места - светлая тема
+final ThemeData lightSightCardTheme = ThemeData(
+  backgroundColor: lightSightCardBackgroundColor,
+  primaryTextTheme: TextTheme(
+    subtitle2: textBold14White,
+    bodyText1: textMedium16BlueZodiac,
+    bodyText2: textRegular14SlateGrey,
+  ),
+);
+
+/// Карточка места - темная тема
+final ThemeData darkSightCardTheme = ThemeData(
+  backgroundColor: darkSightCardBackgroundColor,
+  primaryTextTheme: TextTheme(
+    subtitle2: textBold14White,
+    bodyText1: textMedium16White,
+    bodyText2: textRegular14SlateGrey,
+  ),
+);
+
+/// Детализация места - светлая тема
+final ThemeData lightSightDetailTheme = ThemeData(
+  backgroundColor: lightBackgroundColor,
+  dividerColor: lightSightDetailDividerColor,
+  buttonColor: lightSightDetailButtonColor,
+  primaryTextTheme: TextTheme(
+    bodyText1: textBold24BlueZodiac,
+    bodyText2: textRegular14BlueZodiac,
+    subtitle1: textRegular14SlateGrey,
+    subtitle2: textBold14BlueZodiac,
+  ),
+);
+
+/// Детализация места - темная тема
+final ThemeData darkSightDetailTheme = ThemeData(
+  backgroundColor: darkBackgroundColor,
+  dividerColor: darkSightDetailDividerColor,
+  buttonColor: darkSightDetailButtonColor,
+  primaryTextTheme: TextTheme(
+    bodyText1: textBold24White,
+    bodyText2: textRegular14White,
+    subtitle1: textRegular14SlateGrey,
+    subtitle2: textBold14SlateGrey,
+  ),
+);

--- a/places/lib/ui/screen/res/themes.dart
+++ b/places/lib/ui/screen/res/themes.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:places/ui/res/colors.dart';
 import 'package:places/ui/res/text_styles.dart';
 
-/// Методика использование тем в приложении.
+/// Методика использования тем в приложении.
 ///
 /// Основная тема приложения устанавливается для виджета [MaterialApp].
 /// Параметр [brightness] основной темы является ключевым и позволяет

--- a/places/lib/ui/screen/sight_card.dart
+++ b/places/lib/ui/screen/sight_card.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:places/domain/sight.dart';
-import 'package:places/ui/res/text_styles.dart';
+import 'package:places/ui/screen/res/themes.dart';
 
 /// Карточка места
 class SightCard extends StatelessWidget {
@@ -10,88 +10,102 @@ class SightCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AspectRatio(
-      aspectRatio: 3.0 / 2.0,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(16.0),
-        child: Container(
-          // height: 188,
-          color: Color(0xFFF5F5F5),
-          child: Column(
-            children: [
-              Expanded(
-                flex: 96,
-                child: Container(
-                  child: Stack(
-                    children: [
-                      Image.network(
-                        sight.url,
-                        width: double.infinity,
-                        fit: BoxFit.cover,
-                        loadingBuilder: (BuildContext context, Widget child,
-                            ImageChunkEvent loadingProgress) {
-                          if (loadingProgress == null) return child;
-                          return Center(
-                            child: CircularProgressIndicator(
-                              value: loadingProgress.expectedTotalBytes != null
-                                  ? loadingProgress.cumulativeBytesLoaded /
-                                      loadingProgress.expectedTotalBytes
-                                  : null,
+    return Theme(
+      data: (Theme.of(context).brightness == Brightness.dark)
+          ? darkSightCardTheme
+          : lightSightCardTheme,
+      child: Builder(
+        builder: (BuildContext context) {
+          return AspectRatio(
+            aspectRatio: 3.0 / 2.0,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(16.0),
+              child: Container(
+                color: Theme.of(context).backgroundColor,
+                child: Column(
+                  children: [
+                    Expanded(
+                      flex: 96,
+                      child: Container(
+                        child: Stack(
+                          children: [
+                            Image.network(
+                              sight.url,
+                              width: double.infinity,
+                              fit: BoxFit.cover,
+                              loadingBuilder: (BuildContext context,
+                                  Widget child,
+                                  ImageChunkEvent loadingProgress) {
+                                if (loadingProgress == null) return child;
+                                return Center(
+                                  child: CircularProgressIndicator(
+                                    value: loadingProgress.expectedTotalBytes !=
+                                            null
+                                        ? loadingProgress
+                                                .cumulativeBytesLoaded /
+                                            loadingProgress.expectedTotalBytes
+                                        : null,
+                                  ),
+                                );
+                              },
                             ),
-                          );
-                        },
-                      ),
-                      Positioned(
-                        left: 16,
-                        top: 16,
-                        child: Text(
-                          sight.type,
-                          style: textBold14White,
+                            Positioned(
+                              left: 16,
+                              top: 16,
+                              child: Text(
+                                sight.type,
+                                style: Theme.of(context)
+                                    .primaryTextTheme
+                                    .subtitle2,
+                              ),
+                            ),
+                            Positioned(
+                              right: 18,
+                              top: 19,
+                              child: Container(
+                                width: 20,
+                                height: 18,
+                                color: Colors.white,
+                              ),
+                            ),
+                          ],
                         ),
                       ),
-                      Positioned(
-                        right: 18,
-                        top: 19,
-                        child: Container(
-                          width: 20,
-                          height: 18,
-                          color: Colors.white,
+                    ),
+                    Expanded(
+                      flex: 92,
+                      child: Container(
+                        padding: EdgeInsets.all(16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              sight.name,
+                              style:
+                                  Theme.of(context).primaryTextTheme.bodyText1,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            SizedBox(
+                              height: 2.0,
+                            ),
+                            Text(
+                              sight.detail,
+                              style:
+                                  Theme.of(context).primaryTextTheme.bodyText2,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ],
                         ),
                       ),
-                    ],
-                  ),
+                    )
+                  ],
                 ),
               ),
-              Expanded(
-                flex: 92,
-                child: Container(
-                  padding: EdgeInsets.all(16),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    // mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      Text(
-                        sight.name,
-                        style: textMedium16,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      SizedBox(
-                        height: 2.0,
-                      ),
-                      Text(
-                        sight.detail,
-                        style: textRegular14SlateGrey,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ],
-                  ),
-                ),
-              )
-            ],
-          ),
-        ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/places/lib/ui/screen/sight_detail.dart
+++ b/places/lib/ui/screen/sight_detail.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:places/domain/sight.dart';
-import 'package:places/ui/res/colors.dart';
-import 'package:places/ui/res/text_styles.dart';
+import 'package:places/ui/screen/res/themes.dart';
 
+/// Детализация места
 class SightDetail extends StatelessWidget {
   final Sight sight;
 
@@ -10,108 +10,125 @@ class SightDetail extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SingleChildScrollView(
-        child: Container(
-          color: Colors.white,
-          child: Column(
-            children: [
-              Stack(
-                children: [
-                  Container(
-                    height: 360,
-                    width: double.infinity,
-                    child: Image.network(
-                      sight.url,
-                      fit: BoxFit.cover,
-                      loadingBuilder: (BuildContext context, Widget child,
-                          ImageChunkEvent loadingProgress) {
-                        if (loadingProgress == null) return child;
-                        return Center(
-                          child: CircularProgressIndicator(
-                            value: loadingProgress.expectedTotalBytes != null
-                                ? loadingProgress.cumulativeBytesLoaded /
-                                    loadingProgress.expectedTotalBytes
-                                : null,
-                          ),
-                        );
-                      },
-                    ),
-                  ),
-                  Positioned(
-                    left: 16,
-                    top: 36,
-                    child: Container(
-                      width: 32,
-                      height: 32,
-                      decoration: BoxDecoration(
-                        color: Colors.white,
-                        borderRadius: BorderRadius.circular(10.0),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              SizedBox(height: 24),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+    return Theme(
+      data: (Theme.of(context).brightness == Brightness.dark)
+          ? darkSightDetailTheme
+          : lightSightDetailTheme,
+      child: Builder(
+        builder: (BuildContext context) {
+          return Scaffold(
+            body: SingleChildScrollView(
+              child: Container(
+                color: Theme.of(context).backgroundColor,
                 child: Column(
                   children: [
-                    Container(
+                    Stack(
+                      children: [
+                        Container(
+                          height: 360,
+                          width: double.infinity,
+                          child: Image.network(
+                            sight.url,
+                            fit: BoxFit.cover,
+                            loadingBuilder: (BuildContext context, Widget child,
+                                ImageChunkEvent loadingProgress) {
+                              if (loadingProgress == null) return child;
+                              return Center(
+                                child: CircularProgressIndicator(
+                                  value: loadingProgress.expectedTotalBytes !=
+                                          null
+                                      ? loadingProgress.cumulativeBytesLoaded /
+                                          loadingProgress.expectedTotalBytes
+                                      : null,
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                        Positioned(
+                          left: 16,
+                          top: 36,
+                          child: Container(
+                            width: 32,
+                            height: 32,
+                            decoration: BoxDecoration(
+                              color: Theme.of(context).backgroundColor,
+                              borderRadius: BorderRadius.circular(10.0),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    SizedBox(height: 24),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
                       child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Text(
-                            sight.name,
-                            style: textBold24,
+                          Container(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  sight.name,
+                                  style: Theme.of(context)
+                                      .primaryTextTheme
+                                      .bodyText1,
+                                ),
+                                Container(
+                                  height: 2,
+                                ),
+                                Row(
+                                  children: [
+                                    Text(
+                                      sight.type,
+                                      style: Theme.of(context)
+                                          .primaryTextTheme
+                                          .subtitle2, // textBold14BlueZodiac,
+                                    ),
+                                    Container(width: 16),
+                                    // Заглушка - пока непонятно как получать эти данные - может дальше будет в курсе
+                                    // временно - поэтому не унесено в текстовые константы
+                                    Text(
+                                      "Закрыто до 9:00",
+                                      style: Theme.of(context)
+                                          .primaryTextTheme
+                                          .subtitle1,
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
                           ),
                           Container(
-                            height: 2,
+                            margin: const EdgeInsets.only(top: 24.0),
+                            child: Text(
+                              sight.detail,
+                              style:
+                                  Theme.of(context).primaryTextTheme.bodyText2,
+                            ),
                           ),
-                          Row(
-                            children: [
-                              Text(
-                                sight.type,
-                                style: textBold14,
-                              ),
-                              Container(width: 16),
-                              // Заглушка - пока непонятно как получать эти данные - может дальше будет в курсе
-                              // временно - поэтому не унесено в текстовые константы
-                              Text(
-                                "Закрыто до 9:00",
-                                style: textRegular14SlateGrey,
-                              ),
-                            ],
+                          Container(
+                            margin: const EdgeInsets.only(top: 24.0),
+                            child: TempButtonBuildRoute(),
                           ),
-                        ],
-                      ),
-                    ),
-                    Container(
-                      margin: const EdgeInsets.only(top: 24.0),
-                      child: Text(
-                        sight.detail,
-                        style: textRegular14,
-                      ),
-                    ),
-                    Container(
-                      margin: const EdgeInsets.only(top: 24.0),
-                      child: TempButtonBuildRoute(),
-                    ),
-                    Container(
-                      height: 1,
-                      margin: const EdgeInsets.only(top: 24.0),
-                      color: dividerColor,
-                    ),
-                    Container(
-                      height: 48,
-                      margin: const EdgeInsets.only(top: 8.0),
-                      child: Row(
-                        children: [
-                          Expanded(
-                            child: TempButtonPlan(),
+                          Container(
+                            height: 1,
+                            margin: const EdgeInsets.only(top: 24.0),
+                            color: Theme.of(context).dividerColor,
                           ),
-                          Expanded(
-                            child: TempButtonAddFavorites(),
+                          Container(
+                            height: 48,
+                            margin: const EdgeInsets.only(top: 8.0),
+                            child: Row(
+                              children: [
+                                Expanded(
+                                  child: TempButtonPlan(),
+                                ),
+                                Expanded(
+                                  child: TempButtonAddFavorites(),
+                                ),
+                              ],
+                            ),
                           ),
                         ],
                       ),
@@ -119,9 +136,9 @@ class SightDetail extends StatelessWidget {
                   ],
                 ),
               ),
-            ],
-          ),
-        ),
+            ),
+          );
+        },
       ),
     );
   }
@@ -187,7 +204,7 @@ class TempButtonPlan extends StatelessWidget {
             height: 24,
             decoration: BoxDecoration(
               border: Border.all(
-                color: Color(0xFF7C7E92),
+                color: Theme.of(context).dividerColor,
                 width: 2,
               ),
             ),
@@ -195,9 +212,9 @@ class TempButtonPlan extends StatelessWidget {
           Container(width: 10),
           Text(
             "Запланировать",
-            style: const TextStyle(
+            style: TextStyle(
               fontStyle: FontStyle.normal,
-              color: Color(0xFF7C7E92),
+              color: Theme.of(context).dividerColor,
               fontWeight: FontWeight.w700,
               fontSize: 14,
               height: 18.0 / 14.0,
@@ -226,7 +243,7 @@ class TempButtonAddFavorites extends StatelessWidget {
             height: 24,
             decoration: BoxDecoration(
               border: Border.all(
-                color: Color(0xFF3B3E5C),
+                color: Theme.of(context).buttonColor,
                 width: 2,
               ),
             ),
@@ -234,9 +251,9 @@ class TempButtonAddFavorites extends StatelessWidget {
           Container(width: 10),
           Text(
             "В избранное",
-            style: const TextStyle(
+            style: TextStyle(
               fontStyle: FontStyle.normal,
-              color: Color(0xFF3B3E5C),
+              color: Theme.of(context).buttonColor,
               fontWeight: FontWeight.w700,
               fontSize: 14,
               height: 18.0 / 14.0,

--- a/places/lib/ui/screen/visiting_screen.dart
+++ b/places/lib/ui/screen/visiting_screen.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:places/mocks.dart';
-import 'package:places/ui/res/colors.dart';
 import 'package:places/ui/res/strings.dart';
-import 'package:places/ui/res/text_styles.dart';
 import 'package:places/ui/screen/app_com.dart';
 import 'package:places/ui/screen/sight_card.dart';
 
@@ -18,7 +16,6 @@ class VisitingScreen extends StatelessWidget {
         appBar: AppBar(
           title: Text(
             favAppBarText,
-            style: textMedium18LuckyPoint,
           ),
           centerTitle: true,
           backgroundColor: Colors.transparent,
@@ -32,17 +29,9 @@ class VisitingScreen extends StatelessWidget {
               margin: EdgeInsets.symmetric(vertical: 6, horizontal: 16),
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(40),
-                color: tabbarColorBackground,
+                color: Theme.of(context).cardColor,
               ),
               child: TabBar(
-                indicator: BoxDecoration(
-                  borderRadius: BorderRadius.circular(40),
-                  color: tabbarColorIndicator,
-                ),
-                labelColor: textColorWhite,
-                labelStyle: textBold14,
-                unselectedLabelColor: textColorSlateGrey,
-                unselectedLabelStyle: textBold14,
                 tabs: [
                   Tab(
                     text: favToVizitText,


### PR DESCRIPTION
Для кастомных виджетов (SightCard, SightDetail) хотелось иметь возможность задавать свою тему, но делать свой класс с расширенным набором параметров основной темы казалось излишним - поэтому придумал следующее:

/// Методика использования тем в приложении.
///
/// Основная тема приложения устанавливается для виджета [MaterialApp].
/// Параметр [brightness] основной темы является ключевым и позволяет
/// в дальнейшем, используя [Theme.of(context)], определить установленную
/// сейчас тему (светлая или темная).
///
/// При необходимости, для отдельного виджета может быть установлена
/// специализированная тема (пример - виджеты SightCard, DetailCard).
/// Для этого виджет оборачивается в [Theme] где, в зависимости от значения
/// параметра [brightness] основной темы, устанавливается специализированная
/// тема - светлая или темная. Дополнительно используется [Builder] чтобы
/// обновить [(context)] для последующих виджетов.

![image](https://user-images.githubusercontent.com/73651792/108576081-51ead880-732d-11eb-89a6-a9a745e75873.png)
![image](https://user-images.githubusercontent.com/73651792/108576164-9eceaf00-732d-11eb-9258-bc6560ed93ba.png)
![image](https://user-images.githubusercontent.com/73651792/108576274-0684fa00-732e-11eb-8aed-c37521cbd7f8.png)
![image](https://user-images.githubusercontent.com/73651792/108576310-27e5e600-732e-11eb-9b5c-de81022febe8.png)
![image](https://user-images.githubusercontent.com/73651792/108576344-5237a380-732e-11eb-858b-fcb51dbe323b.png)
![image](https://user-images.githubusercontent.com/73651792/108576386-827f4200-732e-11eb-84b5-af7890c928c6.png)
